### PR TITLE
fixes broken Dockerfile

### DIFF
--- a/cert-helper/Dockerfile
+++ b/cert-helper/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:stretch
 
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
 RUN apt-get update && apt-get install -y ca-certificates
 
 ADD entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
debian:stretch has been archived: https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html

I'm applying this fix: https://unix.stackexchange.com/a/743865